### PR TITLE
If the ip address is not active in the ARP table, there are only 3 co…

### DIFF
--- a/lib/arp.js
+++ b/lib/arp.js
@@ -70,7 +70,7 @@ module.exports.readMACLinux = function(ipaddress, cb) {
 			var table = buffer.split('\n');
 			if (table.length >= 2) {
 				var parts = table[1].split(' ').filter(String);
-				cb(false, parts[2]);
+				cb(false, parts.length == 5 ? parts[2] : parts[1]);
 				return;
 			}
 			cb(true, "Could not find ip in arp table: " + ipaddress);


### PR DESCRIPTION
…lumns on the second row. Switch based on the number of columns to select the correct item.